### PR TITLE
updated to work with new versions of kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.10</artifactId>
+            <artifactId>kafka_2.11</artifactId>
             <version>${kafka.version}</version>
         </dependency>
 
@@ -126,7 +126,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>0.8.0</kafka.version>
+        <kafka.version>0.8.2.1</kafka.version>
         <log4j.version>1.2.15</log4j.version>
         <slf4j.version>1.6.4</slf4j.version>
         <snappy-java.version>1.0.4.1</snappy-java.version>
@@ -220,6 +220,10 @@
                                 <includes>
                                     <include>*:*</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>org.apache.kafka:*</exclude>
+                                    <exclude>log4j:*</exclude>
+                                </excludes>
                             </artifactSet>
                             <minimizeJar>true</minimizeJar>
                             <filters>

--- a/src/main/java/nl/techop/kafka/KafkaHttpMetricsReporter.java
+++ b/src/main/java/nl/techop/kafka/KafkaHttpMetricsReporter.java
@@ -25,9 +25,9 @@ import org.apache.log4j.Logger;
 
 /**
  * Class KafkaHttpMetricsReporter
- * <p/>
+ * &lt;p/&gt;
  * Author: arnobroekhof
- * <p/>
+ * &lt;p/&gt;
  * Purpose: Main class that is being called by Kafka on startup. This Class is also repsonsible for looking up the
  * metric settings as configured in the kafka server.properties file en based on those settings it starts the
  * embedded Jetty Server with the CodaStale servlets attached to it.

--- a/src/main/java/nl/techop/kafka/KafkaHttpMetricsReporterMBean.java
+++ b/src/main/java/nl/techop/kafka/KafkaHttpMetricsReporterMBean.java
@@ -22,9 +22,9 @@ import kafka.metrics.KafkaMetricsReporterMBean;
 
 /**
  * Interface: KafkaHttpMetricsReporterMBean
- * <p/>
+ * &lt;p/&gt;
  * Author: arnobroekhof
- * <p/>
+ * &lt;p/&gt;
  * Purpose: Extending the KafkaMetricsReporterMBean
  */
 public interface KafkaHttpMetricsReporterMBean extends

--- a/src/main/java/nl/techop/kafka/KafkaHttpMetricsServer.java
+++ b/src/main/java/nl/techop/kafka/KafkaHttpMetricsServer.java
@@ -30,11 +30,11 @@ import java.net.InetSocketAddress;
 
 /**
  * Class KafkaHttpMetricsServer
- * <p/>
+ * &lt;p/&gt;
  * Author: arnobroekhof
- * <p/>
+ * &lt;p/&gt;
  * Purpose: Class for starting a Embedded Jetty server with the codahale metrics servlets loaded
- * <p/>
+ * &lt;p/&gt;
  * Interfaces: None
  */
 public class KafkaHttpMetricsServer {
@@ -46,7 +46,7 @@ public class KafkaHttpMetricsServer {
 
   /**
    * Method: KafkaHttpMetricsServer
-   * <p/>
+   * &lt;p/&gt;
    * Purpose: Method for constructing the the metrics server.
    *
    * @param bindAddress the name or address to bind on ( defaults to localhost )
@@ -64,7 +64,7 @@ public class KafkaHttpMetricsServer {
 
   /**
    * Method: init
-   * <p/>
+   * &lt;p/&gt;
    * Purpose: Initializes the embedded Jetty Server with including the metrics servlets.
    */
   private void init() {
@@ -96,7 +96,7 @@ public class KafkaHttpMetricsServer {
 
   /**
    * Method: start
-   * <p/>
+   * &lt;p/&gt;
    * Purpose: starting the metrics server
    */
   public void start() {
@@ -113,7 +113,7 @@ public class KafkaHttpMetricsServer {
 
   /**
    * Method: stop
-   * <p/>
+   * &lt;p/&gt;
    * Purpose: Stopping the metrics server
    */
   public void stop() {


### PR DESCRIPTION
will now work with any version that has a compatible api, uber jar excludes kafka so it wont conflict with the classpath when added to the lib dir.